### PR TITLE
Implement address parsing API

### DIFF
--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -27,7 +27,7 @@ function submitClicked() {
    }
 
    //send address to parser
-   fetch("/api/parse?" + new URLSearchParams({address:address}).toString())
+   fetch("/api/parse/?" + new URLSearchParams({address:address}).toString())
       .then(response => {
          console.log("we're in the then block")
          console.log(response);

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -21,7 +21,7 @@ function submitClicked() {
    const address = document.querySelector("#address").value; //should get address string
    console.log("address:", address)
 
-   if (address == '') {
+   if (address.trim() == '') {
       displayError('No input detected. Please enter an address to parse.');
       return;
    }

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -3,10 +3,8 @@
 
 window.onload = setSubmitBtnListener;
 
-// pick up submit button press
-
 function setSubmitBtnListener() {
-   console.log("Lookin for buttons");
+   // set up listener for a form submit event
    const form = document.querySelector('form');
    form.addEventListener('submit', event => {
       event.preventDefault();
@@ -15,11 +13,9 @@ function setSubmitBtnListener() {
 }
 
 function submitClicked() {
-   console.log("Submit button clicked!");
-   //get address text
 
+   //get address text
    const address = document.querySelector("#address").value; //should get address string
-   console.log("address:", address)
 
    if (address.trim() == '') {
       displayError('No input detected. Please enter an address to parse.');
@@ -29,11 +25,8 @@ function submitClicked() {
    //send address to parser
    fetch("/api/parse/?" + new URLSearchParams({address:address}).toString())
       .then(response => {
-         console.log("we're in the then block")
-         console.log(response);
          response.json()
             .then(data => {
-               console.log(data);
                if (response.ok){
                   populateResults(data);
                }
@@ -43,20 +36,13 @@ function submitClicked() {
             });
       })
       .catch(err => {
-         console.log("we're in the catch block");
-         console.log(err);
          displayError("There was a problem accessing the parser.")
-
-      //Handle errors
       })
 }
- // send GET request to api/parse/ -- use fetch   <-----NEXT!
- // recieve results back, populate table
 
 function populateResults(data) {
-   console.log("populateResults called!");
 
-   // show results div
+   // make sure results div is visible
    setVisible("results");
    
    const span = document.getElementById("parse-type")
@@ -73,7 +59,6 @@ function populateResults(data) {
       let part = row.insertCell(1);
       part.innerHTML = component;
    }
-   console.log("done populating table")
 }
 
 function displayError(message) {
@@ -83,6 +68,10 @@ function displayError(message) {
 }
 
 function setVisible(type) {
+   // Toggles between the results div and the error div being visible.
+   // Argument is a string ('results' or 'error') corresponding to which 
+   // div to set visible. The other is automatically hidden.
+
    const results_div = document.getElementById("address-results");
    const error_div = document.getElementById("error-display");
 

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -21,6 +21,11 @@ function submitClicked() {
    const address = document.querySelector("#address").value; //should get address string
    console.log("address:", address)
 
+   if (address == '') {
+      displayError('No input detected. Please enter an address to parse.');
+      return;
+   }
+
    //send address to parser
    fetch("/api/parse?" + new URLSearchParams({address:address}).toString())
       .then(response => {
@@ -29,12 +34,18 @@ function submitClicked() {
          response.json()
             .then(data => {
                console.log(data);
-               populateTable(data);
+               if (response.ok){
+                  populateResults(data);
+               }
+               else {
+                  displayError(data['detail'])
+               }
             });
       })
       .catch(err => {
          console.log("we're in the catch block");
          console.log(err);
+         displayError("There was a problem accessing the parser.")
 
       //Handle errors
       })
@@ -42,8 +53,45 @@ function submitClicked() {
  // send GET request to api/parse/ -- use fetch   <-----NEXT!
  // recieve results back, populate table
 
-function populateTable(data) {
-   console.log("populateTable called!");
-   console.log(data);
+function populateResults(data) {
+   console.log("populateResults called!");
 
+   // show results div
+   setVisible("results");
+   
+   const span = document.getElementById("parse-type")
+   span.innerHTML = data['address_type']
+   
+   const table = document.querySelector('table');
+   //clear the table
+   table.innerHTML = '';
+
+   for (component in data["address_components"]) {
+      let row = table.insertRow();
+      let val = row.insertCell(0);
+      val.innerHTML = data["address_components"][component];
+      let part = row.insertCell(1);
+      part.innerHTML = component;
+   }
+   console.log("done populating table")
+}
+
+function displayError(message) {
+   const span=document.getElementById("error");
+   span.innerHTML = message;
+   setVisible("error");
+}
+
+function setVisible(type) {
+   const results_div = document.getElementById("address-results");
+   const error_div = document.getElementById("error-display");
+
+   if (type == 'results') {
+      results_div.style.display = "block";
+      error_div.style.display = "none";
+      }
+   else if (type == 'error') {
+      results_div.style.display = "none";
+      error_div.style.display = "block";
+   }
 }

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -1,2 +1,49 @@
 /* TODO: Flesh this out to connect the form to the API and render results
    in the #address-results div. */
+
+window.onload = setSubmitBtnListener;
+
+// pick up submit button press
+
+function setSubmitBtnListener() {
+   console.log("Lookin for buttons");
+   const form = document.querySelector('form');
+   form.addEventListener('submit', event => {
+      event.preventDefault();
+      submitClicked();
+   });
+}
+
+function submitClicked() {
+   console.log("Submit button clicked!");
+   //get address text
+
+   const address = document.querySelector("#address").value; //should get address string
+   console.log("address:", address)
+
+   //send address to parser
+   fetch("/api/parse?" + new URLSearchParams({address:address}).toString())
+      .then(response => {
+         console.log("we're in the then block")
+         console.log(response);
+         response.json()
+            .then(data => {
+               console.log(data);
+               populateTable(data);
+            });
+      })
+      .catch(err => {
+         console.log("we're in the catch block");
+         console.log(err);
+
+      //Handle errors
+      })
+}
+ // send GET request to api/parse/ -- use fetch   <-----NEXT!
+ // recieve results back, populate table
+
+function populateTable(data) {
+   console.log("populateTable called!");
+   console.log(data);
+
+}

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -32,6 +32,9 @@
           </tbody>
         </table>
       </div>
+      <div id="error-display" style="display:none; white-space:pre-wrap">
+        <p> <strong><span id="error"></span></strong></p>
+      </div>
     </div>
   </div>
 </div>

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -14,11 +14,17 @@ class AddressParse(APIView):
     renderer_classes = [JSONRenderer]
 
     def get(self, request):
+        print("AddressParse.get called!")
+        address = request.query_params['address']
         # TODO: Flesh out this method to parse an address string using the
         # parse() method and return the parsed components to the frontend.
-        return Response({})
+        address_components, address_type = self.parse(address)
+        #print("parsed:", address_components, address_type)
+        return Response({'input_string':address, 'address_components':address_components, 'address_type':address_type})
 
     def parse(self, address):
+
         # TODO: Implement this method to return the parsed components of a
         # given address using usaddress: https://github.com/datamade/usaddress
+        address_components, address_type = usaddress.tag(address)
         return address_components, address_type

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -14,8 +14,17 @@ class AddressParse(APIView):
     renderer_classes = [JSONRenderer]
 
     def get(self, request):
-        # TODO: Flesh out this method to parse an address string using the
-        # parse() method and return the parsed components to the frontend.
+        """
+        Given a rest_framework.Request with an 'address' key, return a Response object
+        with the keys:
+            - 'input_string' : the string passed in as 'address'
+            - 'address_components': a dictionary of parsed address components as returned
+                                    by usaddress.tag
+            - 'address_type': a string with the address type as returned by usaddress.tag
+        If there is an error in parsing the address, raise a ParseError which includes
+        the error message in its 'detail' field.
+        """
+
         address = request.query_params['address']
         try:
             address_components, address_type = self.parse(address)
@@ -28,7 +37,10 @@ class AddressParse(APIView):
             raise ParseError(detail=exc.message)
 
     def parse(self, address):
-        # TODO: Implement this method to return the parsed components of a
-        # given address using usaddress: https://github.com/datamade/usaddress
+        """
+        Given a string, try to parse it into address components using usaddress.tag.
+        Return a tuple of (address_components, address_type)
+        """
+
         address_components, address_type = usaddress.tag(address)
         return address_components, address_type

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -24,8 +24,11 @@ class AddressParse(APIView):
         If there is an error in parsing the address, raise a ParseError which includes
         an error message in its 'detail' field.
         """
+        try:
+            address = request.query_params['address']
+        except KeyError:
+            raise ParseError("Invalid request. Missing 'address' parameter.")
 
-        address = request.query_params['address']
         try:
             address_components, address_type = self.parse(address)
             return Response({

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -18,9 +18,13 @@ class AddressParse(APIView):
         address = request.query_params['address']
         # TODO: Flesh out this method to parse an address string using the
         # parse() method and return the parsed components to the frontend.
-        address_components, address_type = self.parse(address)
-        #print("parsed:", address_components, address_type)
-        return Response({'input_string':address, 'address_components':address_components, 'address_type':address_type})
+        try:
+            address_components, address_type = self.parse(address)
+            #print("parsed:", address_components, address_type)
+            return Response({'input_string':address, 'address_components':address_components, 'address_type':address_type})
+        except Exception as exc:
+            raise ParseError(detail=exc.message)
+
 
     def parse(self, address):
 

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -14,20 +14,20 @@ class AddressParse(APIView):
     renderer_classes = [JSONRenderer]
 
     def get(self, request):
-        print("AddressParse.get called!")
-        address = request.query_params['address']
         # TODO: Flesh out this method to parse an address string using the
         # parse() method and return the parsed components to the frontend.
+        address = request.query_params['address']
         try:
             address_components, address_type = self.parse(address)
-            #print("parsed:", address_components, address_type)
-            return Response({'input_string':address, 'address_components':address_components, 'address_type':address_type})
+            return Response({
+                'input_string': address,
+                'address_components': address_components,
+                'address_type': address_type,
+                })
         except Exception as exc:
             raise ParseError(detail=exc.message)
 
-
     def parse(self, address):
-
         # TODO: Implement this method to return the parsed components of a
         # given address using usaddress: https://github.com/datamade/usaddress
         address_components, address_type = usaddress.tag(address)

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -22,7 +22,7 @@ class AddressParse(APIView):
                                     by usaddress.tag
             - 'address_type': a string with the address type as returned by usaddress.tag
         If there is an error in parsing the address, raise a ParseError which includes
-        the error message in its 'detail' field.
+        an error message in its 'detail' field.
         """
 
         address = request.query_params['address']
@@ -33,8 +33,9 @@ class AddressParse(APIView):
                 'address_components': address_components,
                 'address_type': address_type,
                 })
-        except Exception as exc:
-            raise ParseError(detail=exc.message)
+        except usaddress.RepeatedLabelError:
+            raise ParseError(detail='The address "%s" could not be parsed. Please check that the address is correct and try again.\
+                \n\n To report an error in parsing a valid address, please open an issue at https://github.com/datamade/usaddress/issues/new' % address)
 
     def parse(self, address):
         """

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,6 @@
-import pytest
+# import pytest
 import usaddress
+from collections import OrderedDict
 
 
 def test_api_parse_succeeds(client):
@@ -20,6 +21,11 @@ def test_api_parse_succeeds(client):
     assert 'address_components' in data.keys()
     assert 'address_type' in data.keys()
 
+    # make sure the return data is of the type we expect
+    assert type(data['input_string']) == str
+    assert type(data['address_components']) in [dict, OrderedDict]
+    assert type(data['address_type']) == str
+
     # check the values of the returned data
     assert data['input_string'] == address_string
     address_components, address_type = usaddress.tag(address_string)  # let's assume testing in usaddress makes sure this is correct
@@ -31,11 +37,11 @@ def test_api_parse_raises_error(client):
     # TODO: Finish this test. The address_string below will raise a
     # RepeatedLabelError, so ParseAddress.parse() will not be able to parse it.
 
-    # it's not clear to me what the desired behavior is when usaddress.parse raises an error
-    # I settled on catching that error and passing the information in it back to the user.
-    # However, I could see security reasons where we would want to be more vague about what 
-    # kinds of errors occurred and what information we would want to pass back, and I would 
-    # consult with colleagues about this
+    # it's not clear to me what the desired behavior is when usaddress.parse raises an
+    # error I settled on catching that error and passing the information in it back
+    # to the user. However, I could see security reasons where we would want to be
+    # more vague about what errors occurred and what information we would want to pass
+    # back, and I would consult with colleagues about this
 
     address_string = '123 main st chicago il 123 main st'
 
@@ -47,4 +53,3 @@ def test_api_parse_raises_error(client):
     data = response.data
     assert type(data) == dict
     assert 'detail' in data.keys()
-    

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,15 +1,48 @@
 import pytest
+import usaddress
 
 
 def test_api_parse_succeeds(client):
     # TODO: Finish this test. Send a request to the API and confirm that the
     # data comes back in the appropriate format.
+
     address_string = '123 main st chicago il'
-    pytest.fail()
+    response = client.get("/api/parse/", {'address': address_string})
+
+    assert response.status_code == 200
+
+    # make sure we're returning a dictionary with 3 keys:
+    #       input_string, address_components and address_type
+    data = response.data
+    assert type(data) == dict
+    assert len(data.keys()) == 3
+    assert 'input_string' in data.keys()
+    assert 'address_components' in data.keys()
+    assert 'address_type' in data.keys()
+
+    # check the values of the returned data
+    assert data['input_string'] == address_string
+    address_components, address_type = usaddress.tag(address_string)  # let's assume testing in usaddress makes sure this is correct
+    assert data['address_components'] == address_components
+    assert data['address_type'] == address_type
 
 
 def test_api_parse_raises_error(client):
     # TODO: Finish this test. The address_string below will raise a
     # RepeatedLabelError, so ParseAddress.parse() will not be able to parse it.
+
     address_string = '123 main st chicago il 123 main st'
-    pytest.fail()
+
+    # assert that AddressParse.parse raises a RepeatedLabelError - I don't actually know how to do this
+    #with pytest.raises(usaddress.RepeatedLabelError):
+    #    client.parse(address_string)
+
+    # assert that AddressParse.get returns a response that includes the error
+    response = client.get("/api/parse/", {'address': address_string})
+
+    assert response.status_code == 400
+
+    data = response.data
+    assert type(data) == dict
+    assert 'detail' in data.keys()
+    

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -53,3 +53,16 @@ def test_api_parse_raises_error(client):
     data = response.data
     assert type(data) == dict
     assert 'detail' in data.keys()
+
+
+def test_api_parse_no_address_key(client):
+    # Test that if we return a 400 error (rather than the default 500 error) if we
+    # don't get an 'address' key
+
+    response = client.get("/api/parse/")
+    assert response.status_code == 400
+    assert 'detail' in response.data.keys()
+
+    response = client.get("/api/parse/", {'adddress': "123 E Main St"})
+    assert response.status_code == 400
+    assert 'detail' in response.data.keys()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -31,11 +31,13 @@ def test_api_parse_raises_error(client):
     # TODO: Finish this test. The address_string below will raise a
     # RepeatedLabelError, so ParseAddress.parse() will not be able to parse it.
 
-    address_string = '123 main st chicago il 123 main st'
+    # it's not clear to me what the desired behavior is when usaddress.parse raises an error
+    # I settled on catching that error and passing the information in it back to the user.
+    # However, I could see security reasons where we would want to be more vague about what 
+    # kinds of errors occurred and what information we would want to pass back, and I would 
+    # consult with colleagues about this
 
-    # assert that AddressParse.parse raises a RepeatedLabelError - I don't actually know how to do this
-    #with pytest.raises(usaddress.RepeatedLabelError):
-    #    client.parse(address_string)
+    address_string = '123 main st chicago il 123 main st'
 
     # assert that AddressParse.get returns a response that includes the error
     response = client.get("/api/parse/", {'address': address_string})


### PR DESCRIPTION
## Overview

This PR implements address parsing for the DataMade code challenge. It connects user input at a website to backend code that parses user input using the usaddress library and returns the results. 

## Testing Instructions

* After checking out this branch, start docker-compose with `$docker-compose up`
* In your web browser visit `localhost:8000` You should see the Parserator landing page.
* For testing a working address enter `123 main st chicago il` - This should display a table with the address broken into its component parts and labelled
* For testing an address that should produce an error enter `123 main st chicago il 123 main st` - This should display an error message



